### PR TITLE
feature/QMUN-1296

### DIFF
--- a/Q-municate/Classes/Services/QMServicesFacade/QMApi+Users.m
+++ b/Q-municate/Classes/Services/QMServicesFacade/QMApi+Users.m
@@ -224,11 +224,12 @@
             params.avatarUrl = blob.publicUrl;
         }
         params.blobID = blob.ID;
-
+        NSString *password = weakSelf.currentUser.password;
+        
         [QBRequest updateCurrentUser:params successBlock:^(QBResponse *response, QBUUser *updatedUser) {
             //
             if (response.success) {
-                weakSelf.currentUser.password = updatedUser.password;
+                weakSelf.currentUser.password = password;
             }
             completion(response.success);
         } errorBlock:^(QBResponse *response) {

--- a/Q-municate/Classes/ViewControllers/AuthViewControllers/QMSignUpVC/QMSignUpController.m
+++ b/Q-municate/Classes/ViewControllers/AuthViewControllers/QMSignUpVC/QMSignUpController.m
@@ -60,6 +60,8 @@
 
 - (IBAction)chooseUserPicture:(id)sender {
     
+    [self.view endEditing:YES];
+    
     __weak __typeof(self)weakSelf = self;
     
     [QMImagePicker chooseSourceTypeInVC:self allowsEditing:YES result:^(UIImage *image) {


### PR DESCRIPTION
1. Fixed password becomes nil after user updates profile.
User will now join chat first time correctly if he choosed profile picture on sign up stage.

2. Fixed image picker not appearing when keyboard is shown. Keyboard will now disappear if user clicked on profile picture to chose one.